### PR TITLE
fix: include sortDescending/limit/liveUpdates in query ID and add monotonic commit timestamps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ temp_bench_*
 # ChunkHound cache directory
 .chunkhound/
 .chunkhound.json
+.mcp.json
 
 # API docs build artifacts
 docs/api.json

--- a/db/db.ts
+++ b/db/db.ts
@@ -698,6 +698,9 @@ export class GoatDB<US extends Schema = Schema>
         config.sortBy,
         config.ctx,
         config.schema?.ns,
+        config.sortDescending,
+        config.limit,
+        config.liveUpdates,
       );
     }
     let q = this._openQueries.get(id);

--- a/db/db.ts
+++ b/db/db.ts
@@ -708,6 +708,7 @@ export class GoatDB<US extends Schema = Schema>
       q = new Query({
         ...config,
         db: this as unknown as GoatDB,
+        id,
       }) as unknown as Query<
         Schema,
         Schema,

--- a/db/db.ts
+++ b/db/db.ts
@@ -35,12 +35,7 @@ import type {
   ReadonlyJSONObject,
   ReadonlyJSONValue,
 } from '../base/interfaces.ts';
-import {
-  generateQueryId,
-  Query,
-  type QueryConfig,
-  type QuerySource,
-} from '../repo/query.ts';
+import { Query, type QueryConfig, resolveQueryId } from '../repo/query.ts';
 import { sendLoginEmail } from '../net/rest-api.ts';
 import { normalizeEmail } from '../base/string.ts';
 import { FileImplGet, pathExists } from '../base/json-log/file-impl.ts';
@@ -690,19 +685,7 @@ export class GoatDB<US extends Schema = Schema>
   query<IS extends Schema, CTX extends ReadonlyJSONValue, OS extends IS = IS>(
     config: Omit<QueryConfig<IS, OS, CTX>, 'db'>,
   ): Query<IS, OS, CTX> {
-    let id = config.id;
-    if (!id) {
-      id = generateQueryId(
-        config.source as QuerySource,
-        config.predicate,
-        config.sortBy,
-        config.ctx,
-        config.schema?.ns,
-        config.sortDescending,
-        config.limit,
-        config.liveUpdates,
-      );
-    }
+    const id = resolveQueryId(config);
     let q = this._openQueries.get(id);
     if (!q) {
       q = new Query({

--- a/repo/commit.ts
+++ b/repo/commit.ts
@@ -43,6 +43,53 @@ import {
 } from '../base/core-types/encoding/binary-commit.ts';
 import { DataRegistry } from '../cfds/base/data-registry.ts';
 import { log } from '../logging/log.ts';
+
+let _monoLastTimestamp: number | undefined;
+let _nowFn: () => number = Date.now;
+
+/** @internal Override the clock function for testing. */
+export function setMonotonicNowFn(fn: () => number): void {
+  _nowFn = fn;
+}
+
+/** @internal Reset monotonic state (clock and timestamp) for testing. */
+export function resetMonotonicState(): void {
+  _monoLastTimestamp = undefined;
+  _nowFn = Date.now;
+}
+
+function nextFloat64(value: number): number {
+  // Defensive: callers already validate; this guards against direct misuse.
+  assert(
+    Number.isFinite(value) && value >= 0,
+    'nextFloat64: non-finite or negative value',
+  );
+  if (value < 2 ** -1022) return value + Number.MIN_VALUE;
+  return value + 2 ** (Math.floor(Math.log2(value)) - 52);
+}
+
+/** @internal Generate a strictly increasing timestamp in this runtime.
+ *
+ * Date.now() has 1ms resolution, so commits created in the same millisecond
+ * would otherwise be ordered by their random IDs. A stalled or regressed
+ * clock advances to the next representable float64 value instead. This can
+ * move the timestamp ahead of wall time, but preserves local creation order.
+ * Independent runtimes still use the commit ID as a deterministic tiebreaker.
+ */
+export function nextMonotonicTimestamp(): number {
+  const now = _nowFn();
+  assert(
+    Number.isFinite(now) && now >= 0,
+    'nextMonotonicTimestamp: non-finite or negative clock',
+  );
+  if (_monoLastTimestamp === undefined || now > _monoLastTimestamp) {
+    _monoLastTimestamp = now;
+  } else {
+    _monoLastTimestamp = nextFloat64(_monoLastTimestamp);
+  }
+  return _monoLastTimestamp;
+}
+
 export type CommitResolver = (commitId: string) => Commit;
 
 const gTextDecoder = new TextDecoder();

--- a/repo/commit.ts
+++ b/repo/commit.ts
@@ -58,6 +58,12 @@ export function resetMonotonicState(): void {
   _nowFn = Date.now;
 }
 
+/**
+ * Returns the next representable float64 value strictly above the input.
+ * Used by the monotonic clock to guarantee strictly increasing timestamps
+ * when Date.now() stalls (same millisecond for consecutive commits).
+ * @internal
+ */
 function nextFloat64(value: number): number {
   // Defensive: callers already validate; this guards against direct misuse.
   assert(

--- a/repo/commit.ts
+++ b/repo/commit.ts
@@ -513,7 +513,9 @@ export class FieldCommit extends Commit {
       if (ts instanceof Date) {
         ts = ts.getTime();
       }
-      this._timestamp = ts || Date.now();
+      // `||` (not `??`) so `timestamp: 0` is treated as "not provided" —
+      // consistent with CommitConfig where `undefined` means "use monotonic clock".
+      this._timestamp = ts || nextMonotonicTimestamp();
       this._contents = commitContentsClone(contents);
       // Actively ensure nobody tries to mutate our record. Commits must be
       // immutable.
@@ -629,6 +631,7 @@ export class FieldCommit extends Commit {
     assert(this._key !== undefined, 'commit: missing required field "k"');
     this._session = decoder.get<string>('s')!;
     assert(this._session !== undefined, 'commit: missing required field "s"');
+    // Deserialization uses wall time: reading existing data, not creating new commits
     this._timestamp = decoder.get<number>('ts') ?? Date.now();
     this._parents = decoder.get<string[]>('p') || [];
     this._ancestors = decoder.get<string[]>('a') || []; // Replaces old bloom fields 'af'/'ac'

--- a/repo/query-persistance.ts
+++ b/repo/query-persistance.ts
@@ -182,7 +182,7 @@ export class QueryPersistence {
       this._cachedDataForRepo.set(repoId, map || new Map());
     }
 
-    return queryId ? map?.get(queryId) : undefined;
+    return queryId === undefined ? undefined : map?.get(queryId);
   }
 
   /**

--- a/repo/query.ts
+++ b/repo/query.ts
@@ -280,19 +280,11 @@ export class Query<
    * @param config.sortDescending Optional flag to reverse sort order
    * @param config.liveUpdates Optional flag for live uncommitted updates (default true)
    */
-  constructor({
-    db,
-    id,
-    source,
-    predicate,
-    sortBy,
-    sortDescending,
-    ctx,
-    schema,
-    limit,
-    liveUpdates,
-  }: QueryConfig<IS, OS, CTX>) {
+  constructor(config: QueryConfig<IS, OS, CTX>) {
     super();
+    this.id = resolveQueryId(config);
+    const { db, sortDescending, ctx, schema, limit, liveUpdates } = config;
+    let { source, predicate, sortBy } = config;
     this.db = db;
     if (typeof source === 'string') {
       source = itemPathGetRepoId(source);
@@ -310,17 +302,6 @@ export class Query<
     } else if (typeof sortBy === 'function' && sortDescending) {
       sortBy = (info) => (sortBy as SortDescriptor<OS, CTX>)(info) * -1;
     }
-    this.id = id ||
-      generateQueryId(
-        source as QuerySource,
-        predicate,
-        sortBy,
-        ctx,
-        schema?.ns,
-        sortDescending,
-        limit,
-        liveUpdates,
-      );
     this.context = ctx as CTX;
     this.source = source;
     this.scheme = schema;
@@ -972,6 +953,38 @@ export class Query<
 
 const gGeneratedQueryIds = new Map<string, string>();
 
+/** Resolves an explicit ID or derives one from the unnormalized query config. */
+export function resolveQueryId<
+  IS extends Schema = Schema,
+  OS extends IS = IS,
+  CTX extends ReadonlyJSONValue = ReadonlyJSONValue,
+>(
+  config: Pick<
+    QueryConfig<IS, OS, CTX>,
+    | 'id'
+    | 'source'
+    | 'predicate'
+    | 'sortBy'
+    | 'ctx'
+    | 'schema'
+    | 'sortDescending'
+    | 'limit'
+    | 'liveUpdates'
+  >,
+): string {
+  return config.id ??
+    generateQueryId(
+      config.source,
+      config.predicate,
+      config.sortBy,
+      config.ctx,
+      config.schema?.ns,
+      config.sortDescending,
+      config.limit,
+      config.liveUpdates,
+    );
+}
+
 /**
  * Generates a unique identifier for a query based on its configuration.
  * The ID is deterministic and will be the same for queries with identical:
@@ -993,7 +1006,7 @@ export function generateQueryId<
   OS extends IS = IS,
   CTX extends ReadonlyJSONValue = ReadonlyJSONValue,
 >(
-  source: QuerySource,
+  source: QuerySource<IS, OS>,
   predicate: Predicate<IS, CTX> | undefined,
   sortDescriptor:
     | keyof SchemaDataType<OS>
@@ -1005,32 +1018,33 @@ export function generateQueryId<
   limit?: number,
   liveUpdates?: boolean,
 ): string {
-  let key: string;
-  if (typeof source === 'string') {
-    key = source;
-  } else if (source instanceof Repository) {
-    key = source.path;
-  } else {
-    key = source.id;
-  }
-  key += '|';
-  key += predicate ? predicate.toString() : 'null';
-  key += '|';
-  key += sortDescriptor ? sortDescriptor.toString() : 'null';
-  key += '|';
-  key += JSON.stringify(ctx);
-  key += '|';
-  key += ns;
-  key += '|';
-  key += sortDescending ?? '';
-  key += '|';
-  key += limit ?? '';
-  key += '|';
-  key += liveUpdates ?? '';
+  const sourceId = typeof source === 'string'
+    ? source
+    : source instanceof Repository
+    ? source.path
+    : source.id;
+  const key = [
+    sourceId,
+    predicate,
+    sortDescriptor,
+    ctx,
+    ns,
+    sortDescending,
+    limit,
+    liveUpdates,
+  ].map(queryIdPart).join('');
   let hash = gGeneratedQueryIds.get(key);
   if (!hash) {
     hash = murmur3(key, 0).toString(36);
     gGeneratedQueryIds.set(key, hash);
   }
   return hash;
+}
+
+function queryIdPart(value: unknown): string {
+  if (value === undefined) return 'undefined';
+  if (value === null) return 'null';
+  const type = typeof value;
+  const text = type === 'object' ? JSON.stringify(value) : String(value);
+  return `${type}:${text.length}:${text}`;
 }

--- a/repo/query.ts
+++ b/repo/query.ts
@@ -953,7 +953,7 @@ export class Query<
 
 const gGeneratedQueryIds = new Map<string, string>();
 
-/** Resolves an explicit ID or derives one from the unnormalized query config. */
+/** Resolves an explicit ID or derives one from the normalized query config. */
 export function resolveQueryId<
   IS extends Schema = Schema,
   OS extends IS = IS,
@@ -979,9 +979,9 @@ export function resolveQueryId<
       config.sortBy,
       config.ctx,
       config.schema?.ns,
-      config.sortDescending,
-      config.limit,
-      config.liveUpdates,
+      config.sortDescending ?? false,
+      config.limit || 0,
+      config.liveUpdates ?? true,
     );
 }
 

--- a/repo/query.ts
+++ b/repo/query.ts
@@ -286,9 +286,7 @@ export class Query<
     const { db, sortDescending, ctx, schema, limit, liveUpdates } = config;
     let { source, predicate, sortBy } = config;
     this.db = db;
-    if (typeof source === 'string') {
-      source = itemPathGetRepoId(source);
-    }
+    source = querySourceNormalize(source);
     if (!predicate) {
       predicate = () => true;
     }
@@ -951,7 +949,22 @@ export class Query<
   }
 }
 
+/**
+ * Bound generated-ID memoization to 10,000 entries. New entries past capacity
+ * evict the oldest entry (FIFO) so long-lived processes cannot retain every ID.
+ */
 const gGeneratedQueryIds = new Map<string, string>();
+const MAX_GENERATED_QUERY_IDS = 10_000;
+
+/** @internal Reset the generated query ID cache (for testing). */
+export function resetGeneratedQueryIds(): void {
+  gGeneratedQueryIds.clear();
+}
+
+/** @internal Get the generated query ID cache size (for testing). */
+export function generatedQueryIdsSize(): number {
+  return gGeneratedQueryIds.size;
+}
 
 /** Resolves an explicit ID or derives one from the normalized query config. */
 export function resolveQueryId<
@@ -1018,11 +1031,7 @@ export function generateQueryId<
   limit?: number,
   liveUpdates?: boolean,
 ): string {
-  const sourceId = typeof source === 'string'
-    ? source
-    : source instanceof Repository
-    ? source.path
-    : source.id;
+  const sourceId = querySourceId(querySourceNormalize(source));
   const key = [
     sourceId,
     predicate,
@@ -1037,8 +1046,25 @@ export function generateQueryId<
   if (!hash) {
     hash = murmur3(key, 0).toString(36);
     gGeneratedQueryIds.set(key, hash);
+    if (gGeneratedQueryIds.size > MAX_GENERATED_QUERY_IDS) {
+      const oldest = gGeneratedQueryIds.keys().next().value!;
+      gGeneratedQueryIds.delete(oldest);
+    }
   }
   return hash;
+}
+
+function querySourceNormalize<IS extends Schema, OS extends IS>(
+  source: QuerySource<IS, OS>,
+): QuerySource<IS, OS> {
+  return typeof source === 'string' ? itemPathGetRepoId(source) : source;
+}
+
+function querySourceId<IS extends Schema, OS extends IS>(
+  source: QuerySource<IS, OS>,
+): string {
+  if (typeof source === 'string') return source;
+  return source instanceof Repository ? source.path : source.id;
 }
 
 function queryIdPart(value: unknown): string {

--- a/repo/query.ts
+++ b/repo/query.ts
@@ -133,7 +133,12 @@ export type QueryConfig<
    * If a field name is provided, results will be sorted by that field's values
    * using standard comparison rules. */
   sortBy?: SortDescriptor<OS, CTX> | keyof SchemaDataType<OS>;
-  /** Optional flag that if true, flips the natural order of the sortBy */
+  /** Optional flag that if true, flips the natural order of the sortBy
+   *
+   * WARNING: When adding a field that changes query behavior (sorting,
+   * filtering, limiting, live updates), you MUST also add it to the key
+   * computation in `generateQueryId()` below so the cache identity captures
+   * the difference. Otherwise distinct configurations will collide. */
   sortDescending?: boolean;
   /** Optional schema to restrict query results to */
   schema?: IS;
@@ -272,6 +277,8 @@ export class Query<
    * @param config.ctx Optional context data passed to predicate/sort functions
    * @param config.schema Optional schema type for the query
    * @param config.limit Optional maximum number of results (0 for unlimited)
+   * @param config.sortDescending Optional flag to reverse sort order
+   * @param config.liveUpdates Optional flag for live uncommitted updates (default true)
    */
   constructor({
     db,
@@ -310,6 +317,9 @@ export class Query<
         sortBy,
         ctx,
         schema?.ns,
+        sortDescending,
+        limit,
+        liveUpdates,
       );
     this.context = ctx as CTX;
     this.source = source;
@@ -970,6 +980,9 @@ const gGeneratedQueryIds = new Map<string, string>();
  * - Sort descriptor
  * - Context data
  * - Schema namespace
+ * - sortDescending flag
+ * - limit value
+ * - liveUpdates flag
  *
  * @param IS The input schema type for items in the query
  * @param OS The output schema type for items in the query
@@ -988,6 +1001,9 @@ export function generateQueryId<
     | undefined,
   ctx: CTX | undefined,
   ns: string | null | undefined,
+  sortDescending?: boolean,
+  limit?: number,
+  liveUpdates?: boolean,
 ): string {
   let key: string;
   if (typeof source === 'string') {
@@ -1005,6 +1021,12 @@ export function generateQueryId<
   key += JSON.stringify(ctx);
   key += '|';
   key += ns;
+  key += '|';
+  key += sortDescending ?? '';
+  key += '|';
+  key += limit ?? '';
+  key += '|';
+  key += liveUpdates ?? '';
   let hash = gGeneratedQueryIds.get(key);
   if (!hash) {
     hash = murmur3(key, 0).toString(36);

--- a/tests/commit.test.ts
+++ b/tests/commit.test.ts
@@ -376,4 +376,121 @@ export default function setup() {
       });
     },
   );
+
+  TEST('Commit', 'Commit.create uses monotonic timestamps', () => {
+    withMonotonicClock(() => {
+      setMonotonicNowFn(() => 1_700_000_000_000);
+      const c1 = Commit.create({
+        session: 'sess',
+        orgId: 'org',
+        key: 'k',
+        contents: makeTestItem('a'),
+        parents: [],
+        ancestors: [],
+      });
+      const c2 = Commit.create({
+        session: 'sess',
+        orgId: 'org',
+        key: 'k',
+        contents: makeTestItem('b'),
+        parents: [],
+        ancestors: [],
+      });
+      assertTrue(
+        c1.timestamp < c2.timestamp,
+        'later commit has later timestamp',
+      );
+    });
+  });
+
+  TEST('Commit', 'Commit.create falls back for a falsy timestamp', () => {
+    withMonotonicClock(() => {
+      const now = 1_700_000_000_000;
+      setMonotonicNowFn(() => now);
+      const commit = Commit.create({
+        session: 'sess',
+        orgId: 'org',
+        key: 'k',
+        contents: makeTestItem('a'),
+        parents: [],
+        ancestors: [],
+        timestamp: 0,
+      });
+      assertEquals(commit.timestamp, now);
+    });
+  });
+
+  TEST(
+    'Commit',
+    'deserialization with missing ts gets reasonable timestamp',
+    () => {
+      withMonotonicClock(() => {
+        const commit = Commit.create({
+          session: 'sess',
+          orgId: 'org',
+          key: 'k',
+          contents: makeTestItem('a'),
+          parents: [],
+          ancestors: [],
+          timestamp: 1,
+        });
+        const js = { ...commit.toJS() };
+        delete (js as any).ts;
+        const decoder = JSONCyclicalDecoder.get(js);
+        const decoded = Commit.fromJS('org', decoder, DataRegistry.default);
+        decoder.finalize();
+        // Contract: deserialized commits without timestamps get valid values
+        assertTrue(decoded.timestamp > 0, 'has valid timestamp');
+        assertTrue(Number.isFinite(decoded.timestamp), 'timestamp is finite');
+        assertTrue(
+          decoded.timestamp <= Date.now(),
+          'timestamp not in the future',
+        );
+      });
+    },
+  );
+
+  TEST(
+    'Commit',
+    'deserialization doesn\'t advance monotonic clock',
+    () => {
+      withMonotonicClock(() => {
+        const now = 1_700_000_000_000;
+        setMonotonicNowFn(() => now);
+        // First call sets _monoLastTimestamp
+        const t1 = nextMonotonicTimestamp();
+        assertEquals(t1, now);
+        // Deserialize 100 commits without ts
+        const commit = Commit.create({
+          session: 'sess',
+          orgId: 'org',
+          key: 'k',
+          contents: makeTestItem('a'),
+          parents: [],
+          ancestors: [],
+          timestamp: 1,
+        });
+        const js = { ...commit.toJS() };
+        for (let i = 0; i < 100; i++) {
+          const noTs = { ...js };
+          delete (noTs as any).ts;
+          const decoder = JSONCyclicalDecoder.get(noTs);
+          const decoded = Commit.fromJS('org', decoder, DataRegistry.default);
+          decoder.finalize();
+          // Contract: deserialized commits get valid timestamps
+          assertTrue(decoded.timestamp > 0, 'has valid timestamp');
+          assertTrue(Number.isFinite(decoded.timestamp), 'timestamp is finite');
+        }
+        // Invariant: monotonic clock shouldn't advance from deserialization
+        // (If deserialization used nextMonotonicTimestamp, clock would be 100 ULPs ahead)
+        const tAfter = nextMonotonicTimestamp();
+        assertTrue(
+          tAfter - now < 1,
+          `monotonic clock advanced too far after deserializations: ${
+            tAfter - now
+          }`,
+        );
+      });
+    },
+  );
 }

--- a/tests/commit.test.ts
+++ b/tests/commit.test.ts
@@ -455,7 +455,7 @@ export default function setup() {
 
   TEST(
     'Commit',
-    'deserialization doesn\'t advance monotonic clock',
+    "deserialization doesn't advance monotonic clock",
     () => {
       withMonotonicClock(() => {
         const now = 1_700_000_000_000;

--- a/tests/commit.test.ts
+++ b/tests/commit.test.ts
@@ -1,4 +1,10 @@
-import { Commit, FieldCommit } from '../repo/commit.ts';
+import {
+  Commit,
+  FieldCommit,
+  nextMonotonicTimestamp,
+  resetMonotonicState,
+  setMonotonicNowFn,
+} from '../repo/commit.ts';
 import { Item } from '../cfds/base/item.ts';
 import { Edit } from '../cfds/base/edit.ts';
 import { DataRegistry } from '../cfds/base/data-registry.ts';
@@ -37,6 +43,15 @@ function makeTestEdit(srcChecksum: string, dstChecksum: string) {
     srcChecksum,
     dstChecksum,
   });
+}
+
+function withMonotonicClock(fn: () => void): void {
+  resetMonotonicState();
+  try {
+    fn();
+  } finally {
+    resetMonotonicState();
+  }
 }
 
 export default function setup() {
@@ -222,4 +237,143 @@ export default function setup() {
     });
     decoder.finalize();
   });
+
+  TEST(
+    'Commit',
+    'nextMonotonicTimestamp is monotonic within a stalled ms',
+    () => {
+      withMonotonicClock(() => {
+        setMonotonicNowFn(() => 1_700_000_000_000);
+        const t1 = nextMonotonicTimestamp();
+        const t2 = nextMonotonicTimestamp();
+        const t3 = nextMonotonicTimestamp();
+        assertTrue(t1 < t2, 't1 < t2');
+        assertTrue(t2 < t3, 't2 < t3');
+      });
+    },
+  );
+
+  TEST('Commit', 'nextMonotonicTimestamp uses a new clock ms directly', () => {
+    withMonotonicClock(() => {
+      const ms1 = 1_700_000_000_000;
+      const ms2 = ms1 + 1;
+      setMonotonicNowFn(() => ms1);
+      const t1 = nextMonotonicTimestamp();
+      const t2 = nextMonotonicTimestamp();
+      setMonotonicNowFn(() => ms2);
+      const t3 = nextMonotonicTimestamp();
+      assertTrue(t1 < t2, 't1 < t2 within same ms');
+      assertEquals(t3, ms2, 'new ms returns raw Date.now()');
+    });
+  });
+
+  TEST('Commit', 'nextMonotonicTimestamp handles clock regression', () => {
+    withMonotonicClock(() => {
+      setMonotonicNowFn(() => 1_700_000_000_000);
+      const t1 = nextMonotonicTimestamp();
+      setMonotonicNowFn(() => 1_699_999_999_000);
+      assertTrue(nextMonotonicTimestamp() > t1, 'timestamp remains monotonic');
+    });
+  });
+
+  TEST('Commit', 'nextMonotonicTimestamp handles the Unix epoch', () => {
+    withMonotonicClock(() => {
+      setMonotonicNowFn(() => 0);
+      const t1 = nextMonotonicTimestamp();
+      const t2 = nextMonotonicTimestamp();
+      assertEquals(t1, 0, 'first timestamp is the clock value');
+      assertTrue(t2 > t1, 'second timestamp advances from zero');
+    });
+  });
+
+  TEST(
+    'Commit',
+    'nextMonotonicTimestamp remains monotonic beyond one ms',
+    () => {
+      withMonotonicClock(() => {
+        const ms = 1_700_000_000_000;
+        setMonotonicNowFn(() => ms);
+        let previous = nextMonotonicTimestamp();
+        for (let i = 0; i < 5_000; i++) {
+          const timestamp = nextMonotonicTimestamp();
+          assertTrue(
+            timestamp > previous,
+            'timestamps remain strictly increasing',
+          );
+          previous = timestamp;
+        }
+        assertTrue(
+          previous > ms + 1,
+          'logical time advances when the clock stalls',
+        );
+      });
+    },
+  );
+
+  TEST('Commit', 'resetMonotonicState cleans module state', () => {
+    withMonotonicClock(() => {
+      setMonotonicNowFn(() => 42);
+      nextMonotonicTimestamp();
+      nextMonotonicTimestamp();
+      resetMonotonicState();
+      setMonotonicNowFn(() => 99);
+      assertEquals(nextMonotonicTimestamp(), 99);
+    });
+  });
+
+  TEST('Commit', 'nextMonotonicTimestamp rejects negative clock', () => {
+    withMonotonicClock(() => {
+      setMonotonicNowFn(() => -1);
+      assertThrows(() => nextMonotonicTimestamp());
+    });
+  });
+
+  TEST('Commit', 'nextMonotonicTimestamp rejects Infinity clock', () => {
+    withMonotonicClock(() => {
+      setMonotonicNowFn(() => Infinity);
+      assertThrows(() => nextMonotonicTimestamp());
+    });
+  });
+
+  TEST('Commit', 'nextMonotonicTimestamp rejects NaN clock', () => {
+    withMonotonicClock(() => {
+      setMonotonicNowFn(() => NaN);
+      assertThrows(() => nextMonotonicTimestamp());
+    });
+  });
+
+  TEST(
+    'Commit',
+    'nextFloat64 maintains precision at high iteration count',
+    () => {
+      withMonotonicClock(() => {
+        // Use realistic Date.now() range (~1.7e12)
+        const startMs = 1_700_000_000_000;
+        setMonotonicNowFn(() => startMs);
+        let previous = nextMonotonicTimestamp();
+        const iterations = 100_000;
+        for (let i = 0; i < iterations; i++) {
+          const next = nextMonotonicTimestamp();
+          // Invariant: each timestamp is strictly greater
+          assertTrue(
+            next > previous,
+            `iteration ${i}: monotonicity violated (next=${next}, prev=${previous})`,
+          );
+          // Invariant: no precision loss (advancement > 0)
+          assertTrue(
+            next - previous > 0,
+            `iteration ${i}: no advancement`,
+          );
+          previous = next;
+        }
+        // Verify total advancement is reasonable (doesn't overflow into next ms too quickly)
+        // At 1.7e12 range, ULP ≈ 0.000244ms, so 100k iterations should advance ~24ms
+        const totalAdvancement = previous - startMs;
+        assertTrue(
+          totalAdvancement > 10 && totalAdvancement < 100,
+          `total advancement ${totalAdvancement}ms is outside expected range [10, 100]`,
+        );
+      });
+    },
+  );
 }

--- a/tests/commit.test.ts
+++ b/tests/commit.test.ts
@@ -5,6 +5,7 @@ import {
   resetMonotonicState,
   setMonotonicNowFn,
 } from '../repo/commit.ts';
+import { resetGeneratedQueryIds } from '../repo/query.ts';
 import { Item } from '../cfds/base/item.ts';
 import { Edit } from '../cfds/base/edit.ts';
 import { DataRegistry } from '../cfds/base/data-registry.ts';
@@ -47,10 +48,12 @@ function makeTestEdit(srcChecksum: string, dstChecksum: string) {
 
 function withMonotonicClock(fn: () => void): void {
   resetMonotonicState();
+  resetGeneratedQueryIds();
   try {
     fn();
   } finally {
     resetMonotonicState();
+    resetGeneratedQueryIds();
   }
 }
 

--- a/tests/db-trusted.test.ts
+++ b/tests/db-trusted.test.ts
@@ -8,6 +8,9 @@ import {
 import { TEST } from './mod.ts';
 import { isBrowser } from '../base/common.ts';
 import type { GoatDB } from '../db/db.ts';
+import { Query } from '../repo/query.ts';
+import { QueryPersistence } from '../repo/query-persistance.ts';
+import { QueryPersistenceFile } from '../db/persistance/query-file.ts';
 
 // Define a test schema
 const TestSchema = {
@@ -19,8 +22,14 @@ const TestSchema = {
   },
 } as const;
 
+const OtherTestSchema = {
+  ...TestSchema,
+  ns: 'other-test',
+} as const;
+
 const kDataRegistry = new DataRegistry();
 kDataRegistry.registerSchema(TestSchema);
+kDataRegistry.registerSchema(OtherTestSchema);
 export default function setup(): void {
   TEST('Trusted', 'initialization', async (ctx) => {
     const db = await ctx.createDB('db-init', {
@@ -223,6 +232,74 @@ export default function setup(): void {
       await db.close();
     }
   });
+
+  TEST(
+    'Trusted',
+    'query IDs retain raw config and explicit empty IDs',
+    async (ctx) => {
+      const db = await ctx.createDB('db-query-ids', {
+        registry: kDataRegistry,
+      });
+      const queries: Array<{ close(): void }> = [];
+      const persistence = new QueryPersistence(
+        new QueryPersistenceFile(db.path),
+      );
+
+      try {
+        await db.readyPromise();
+        db.create('/test/query-ids', TestSchema, { name: 'Item', count: 1 });
+        await db.flush('/test/query-ids');
+        await persistence.storage!.store('/test/query-ids', {
+          version: 1,
+          queries: { '': { age: 1, results: [] } },
+        });
+        assertExists(
+          await persistence.get('/test/query-ids', ''),
+          'empty query IDs must be retrieved from persistence',
+        );
+
+        const base = { source: '/test/query-ids', schema: TestSchema };
+        const byName = db.query({ ...base, sortBy: 'name' });
+        queries.push(byName);
+        const sameByName = db.query({ ...base, sortBy: 'name' });
+        const byCount = db.query({ ...base, sortBy: 'count' });
+        queries.push(byCount);
+        const otherNs = db.query({
+          ...base,
+          schema: OtherTestSchema,
+          sortBy: 'name',
+        });
+        queries.push(otherNs);
+        assertEquals(byName, sameByName);
+        assertTrue(byName.id !== byCount.id, 'sort fields must change the ID');
+        assertTrue(
+          byName.id !== otherNs.id,
+          'schema namespace must change the ID',
+        );
+
+        const dbEmptyId = db.query({ ...base, id: '' });
+        queries.push(dbEmptyId);
+        assertEquals(dbEmptyId, db.query({ ...base, id: '' }));
+        assertEquals(dbEmptyId.id, '');
+        await dbEmptyId.loadingFinished();
+
+        const directByName = new Query({ db, ...base, sortBy: 'name' });
+        const directByCount = new Query({ db, ...base, sortBy: 'count' });
+        const directEmptyId = new Query({ db, ...base, id: '' });
+        queries.push(directByName, directByCount, directEmptyId);
+        assertTrue(
+          directByName.id !== directByCount.id,
+          'direct Query sort fields must change the ID',
+        );
+        assertEquals(directEmptyId.id, '');
+      } finally {
+        await persistence.close();
+        for (const query of queries) query.close();
+        await db.flushAll();
+        await db.close();
+      }
+    },
+  );
 
   TEST('Trusted', 'query cache cross-session correctness', async (ctx) => {
     // Regression test: ageForKey was keyed by item key but looked up by full

--- a/tests/db-trusted.test.ts
+++ b/tests/db-trusted.test.ts
@@ -271,6 +271,11 @@ export default function setup(): void {
           }),
           'omitted and explicit defaults must deduplicate',
         );
+        assertEquals(
+          defaults,
+          db.query({ ...base, source: '/test/query-ids/item' }),
+          'repository and item paths must deduplicate',
+        );
 
         const byName = db.query({ ...base, sortBy: 'name' });
         queries.push(byName);
@@ -296,10 +301,27 @@ export default function setup(): void {
         assertEquals(dbEmptyId.id, '');
         await dbEmptyId.loadingFinished();
 
+        const directRepoPath = new Query({ db, ...base });
+        const directItemPath = new Query({
+          db,
+          ...base,
+          source: '/test/query-ids/item',
+        });
         const directByName = new Query({ db, ...base, sortBy: 'name' });
         const directByCount = new Query({ db, ...base, sortBy: 'count' });
         const directEmptyId = new Query({ db, ...base, id: '' });
-        queries.push(directByName, directByCount, directEmptyId);
+        queries.push(
+          directRepoPath,
+          directItemPath,
+          directByName,
+          directByCount,
+          directEmptyId,
+        );
+        assertEquals(
+          directRepoPath.id,
+          directItemPath.id,
+          'direct Query repository and item paths must have the same ID',
+        );
         assertTrue(
           directByName.id !== directByCount.id,
           'direct Query sort fields must change the ID',

--- a/tests/db-trusted.test.ts
+++ b/tests/db-trusted.test.ts
@@ -235,7 +235,7 @@ export default function setup(): void {
 
   TEST(
     'Trusted',
-    'query IDs retain raw config and explicit empty IDs',
+    'query IDs normalize defaults and retain explicit empty IDs',
     async (ctx) => {
       const db = await ctx.createDB('db-query-ids', {
         registry: kDataRegistry,
@@ -259,6 +259,19 @@ export default function setup(): void {
         );
 
         const base = { source: '/test/query-ids', schema: TestSchema };
+        const defaults = db.query(base);
+        queries.push(defaults);
+        assertEquals(
+          defaults,
+          db.query({
+            ...base,
+            sortDescending: false,
+            limit: 0,
+            liveUpdates: true,
+          }),
+          'omitted and explicit defaults must deduplicate',
+        );
+
         const byName = db.query({ ...base, sortBy: 'name' });
         queries.push(byName);
         const sameByName = db.query({ ...base, sortBy: 'name' });

--- a/tests/merge-edge-cases.test.ts
+++ b/tests/merge-edge-cases.test.ts
@@ -1,11 +1,47 @@
 import { TEST } from './mod.ts';
 import { assertEquals, assertExists, assertTrue } from './asserts.ts';
+import { resetMonotonicState, setMonotonicNowFn } from '../repo/commit.ts';
 import {
   createRawCommit,
   kMergeTestRegistry,
   kMergeTestSchemaV1,
 } from './merge-test-utils.ts';
 export default function setup() {
+  TEST(
+    'MergeEdgeCases',
+    'monotonic clock ensures same-ms commits preserve creation order',
+    async (ctx) => {
+      const db = await ctx.createDB('edge-monotonic', {
+        registry: kMergeTestRegistry,
+      });
+      try {
+        await db.readyPromise();
+        await db.open('/merge-test/edge-monotonic');
+        const repo = db.repository('/merge-test/edge-monotonic')!;
+        resetMonotonicState();
+        setMonotonicNowFn(() => 1_700_000_000_000);
+        const earlier = createRawCommit({
+          id: 'z-earlier',
+          key: 'k1',
+          schema: kMergeTestSchemaV1,
+          data: { title: 'earlier' },
+        });
+        const later = createRawCommit({
+          id: 'a-later',
+          key: 'k1',
+          schema: kMergeTestSchemaV1,
+          data: { title: 'later' },
+        });
+        await repo.persistVerifiedCommits([earlier, later]);
+        assertEquals(repo.headForKey('k1')?.id, later.id);
+      } finally {
+        resetMonotonicState();
+        await db.flushAll();
+        await db.close();
+      }
+    },
+  );
+
   TEST(
     'MergeEdgeCases',
     'compareCommitsDesc same-timestamp deterministic',

--- a/tests/merge-edge-cases.test.ts
+++ b/tests/merge-edge-cases.test.ts
@@ -1,6 +1,7 @@
 import { TEST } from './mod.ts';
 import { assertEquals, assertExists, assertTrue } from './asserts.ts';
 import { resetMonotonicState, setMonotonicNowFn } from '../repo/commit.ts';
+import { resetGeneratedQueryIds } from '../repo/query.ts';
 import {
   createRawCommit,
   kMergeTestRegistry,
@@ -19,6 +20,7 @@ export default function setup() {
         await db.open('/merge-test/edge-monotonic');
         const repo = db.repository('/merge-test/edge-monotonic')!;
         resetMonotonicState();
+        resetGeneratedQueryIds();
         setMonotonicNowFn(() => 1_700_000_000_000);
         const earlier = createRawCommit({
           id: 'z-earlier',
@@ -36,6 +38,7 @@ export default function setup() {
         assertEquals(repo.headForKey('k1')?.id, later.id);
       } finally {
         resetMonotonicState();
+        resetGeneratedQueryIds();
         await db.flushAll();
         await db.close();
       }
@@ -53,6 +56,7 @@ export default function setup() {
         await db.readyPromise();
         await db.open('/merge-test/edge1');
         const repo = db.repository('/merge-test/edge1')!;
+        resetGeneratedQueryIds();
 
         const now = Date.now();
         // Create 2 commits with identical timestamps but different data/IDs

--- a/tests/merge-test-utils.ts
+++ b/tests/merge-test-utils.ts
@@ -87,6 +87,7 @@ export function createTestDomainConfig() {
 // --- Helpers ---
 
 export interface RawCommitOpts {
+  id?: string;
   session?: string;
   orgId?: string;
   key: string;
@@ -112,6 +113,7 @@ export function createRawCommit(opts: RawCommitOpts): Commit {
     kMergeTestRegistry,
   );
   return Commit.create({
+    id: opts.id,
     session: opts.session ?? 'test-session',
     orgId: opts.orgId ?? 'test-org',
     key: opts.key,

--- a/tests/query-id.test.ts
+++ b/tests/query-id.test.ts
@@ -1,0 +1,343 @@
+/**
+ * Unit tests for `generateQueryId` — the deterministic cache-key function
+ * that powers query deduplication and persistence.
+ *
+ * These are pure-function tests (no DB, no I/O) so they run in <1ms.
+ */
+import { assertEquals, assertTrue } from './asserts.ts';
+import { TEST } from './mod.ts';
+import { generateQueryId } from '../repo/query.ts';
+
+// Stable inputs used as baseline for all tests.
+const kSource = '/data/items';
+const kPredicate = undefined;
+const kSortBy = undefined;
+const kCtx = undefined;
+const kNs = 'test-ns';
+
+export default function setup(): void {
+  // --- Determinism ----------------------------------------------------------
+  TEST(
+    'QueryId',
+    'same inputs produce same output',
+    () => {
+      const a = generateQueryId(
+        kSource,
+        kPredicate,
+        kSortBy,
+        kCtx,
+        kNs,
+        false,
+        10,
+        true,
+      );
+      const b = generateQueryId(
+        kSource,
+        kPredicate,
+        kSortBy,
+        kCtx,
+        kNs,
+        false,
+        10,
+        true,
+      );
+      assertEquals(a, b);
+    },
+  );
+
+  // --- sortDescending independence ------------------------------------------
+  TEST(
+    'QueryId',
+    'sortDescending:false and sortDescending:true produce different IDs',
+    () => {
+      const a = generateQueryId(
+        kSource,
+        kPredicate,
+        kSortBy,
+        kCtx,
+        kNs,
+        false,
+        10,
+        true,
+      );
+      const b = generateQueryId(
+        kSource,
+        kPredicate,
+        kSortBy,
+        kCtx,
+        kNs,
+        true,
+        10,
+        true,
+      );
+      assertTrue(a !== b, `IDs should differ: ${a}`);
+    },
+  );
+
+  TEST(
+    'QueryId',
+    'sortDescending:undefined produces a distinct ID from false and true',
+    () => {
+      const undef = generateQueryId(
+        kSource,
+        kPredicate,
+        kSortBy,
+        kCtx,
+        kNs,
+        undefined,
+        10,
+        true,
+      );
+      const falsy = generateQueryId(
+        kSource,
+        kPredicate,
+        kSortBy,
+        kCtx,
+        kNs,
+        false,
+        10,
+        true,
+      );
+      const truthy = generateQueryId(
+        kSource,
+        kPredicate,
+        kSortBy,
+        kCtx,
+        kNs,
+        true,
+        10,
+        true,
+      );
+      assertTrue(undef !== falsy, 'undefined vs false');
+      assertTrue(undef !== truthy, 'undefined vs true');
+      assertTrue(falsy !== truthy, 'false vs true');
+    },
+  );
+
+  // --- limit independence ---------------------------------------------------
+  TEST(
+    'QueryId',
+    'different limit values produce different IDs',
+    () => {
+      const ids = [undefined, 0, 1, 10, 100].map((limit) =>
+        generateQueryId(
+          kSource,
+          kPredicate,
+          kSortBy,
+          kCtx,
+          kNs,
+          false,
+          limit,
+          true,
+        )
+      );
+      // All 5 must be unique
+      const unique = new Set(ids);
+      assertEquals(unique.size, ids.length, `collision among limits: ${ids}`);
+    },
+  );
+
+  // --- liveUpdates independence ---------------------------------------------
+  TEST(
+    'QueryId',
+    'liveUpdates:false and liveUpdates:true produce different IDs',
+    () => {
+      const a = generateQueryId(
+        kSource,
+        kPredicate,
+        kSortBy,
+        kCtx,
+        kNs,
+        false,
+        10,
+        true,
+      );
+      const b = generateQueryId(
+        kSource,
+        kPredicate,
+        kSortBy,
+        kCtx,
+        kNs,
+        false,
+        10,
+        false,
+      );
+      assertTrue(a !== b, `IDs should differ: ${a}`);
+    },
+  );
+
+  TEST(
+    'QueryId',
+    'liveUpdates:undefined produces a distinct ID from false and true',
+    () => {
+      const undef = generateQueryId(
+        kSource,
+        kPredicate,
+        kSortBy,
+        kCtx,
+        kNs,
+        false,
+        10,
+        undefined,
+      );
+      const falsy = generateQueryId(
+        kSource,
+        kPredicate,
+        kSortBy,
+        kCtx,
+        kNs,
+        false,
+        10,
+        false,
+      );
+      const truthy = generateQueryId(
+        kSource,
+        kPredicate,
+        kSortBy,
+        kCtx,
+        kNs,
+        false,
+        10,
+        true,
+      );
+      assertTrue(undef !== falsy, 'undefined vs false');
+      assertTrue(undef !== truthy, 'undefined vs true');
+      assertTrue(falsy !== truthy, 'false vs true');
+    },
+  );
+
+  // --- Regression: issue #46 ------------------------------------------------
+  TEST(
+    'QueryId',
+    'configs differing only in sortDescending/limit/liveUpdates produce distinct IDs (#46)',
+    () => {
+      const base = generateQueryId(
+        kSource,
+        kPredicate,
+        kSortBy,
+        kCtx,
+        kNs,
+      );
+      const withSortDesc = generateQueryId(
+        kSource,
+        kPredicate,
+        kSortBy,
+        kCtx,
+        kNs,
+        true,
+      );
+      const withLimit = generateQueryId(
+        kSource,
+        kPredicate,
+        kSortBy,
+        kCtx,
+        kNs,
+        undefined,
+        50,
+      );
+      const withLive = generateQueryId(
+        kSource,
+        kPredicate,
+        kSortBy,
+        kCtx,
+        kNs,
+        undefined,
+        undefined,
+        false,
+      );
+      const allThree = generateQueryId(
+        kSource,
+        kPredicate,
+        kSortBy,
+        kCtx,
+        kNs,
+        true,
+        50,
+        false,
+      );
+
+      const ids = [base, withSortDesc, withLimit, withLive, allThree];
+      const unique = new Set(ids);
+      assertEquals(
+        unique.size,
+        ids.length,
+        `collision among config variants: ${ids}`,
+      );
+    },
+  );
+
+  // --- Source type variants -------------------------------------------------
+  TEST(
+    'QueryId',
+    'different source strings produce different IDs',
+    () => {
+      const a = generateQueryId(
+        '/data/items',
+        kPredicate,
+        kSortBy,
+        kCtx,
+        kNs,
+      );
+      const b = generateQueryId(
+        '/data/other',
+        kPredicate,
+        kSortBy,
+        kCtx,
+        kNs,
+      );
+      assertTrue(a !== b, `IDs should differ: ${a}`);
+    },
+  );
+
+  // --- Predicate / sortBy independence (pre-existing, lock down) ------------
+  TEST(
+    'QueryId',
+    'different predicates produce different IDs',
+    () => {
+      // deno-lint-ignore no-explicit-any
+      const predA: any = ({ item }: { item: { get: (k: string) => number } }) =>
+        item.get('value') > 5;
+      // deno-lint-ignore no-explicit-any
+      const predB: any = ({ item }: { item: { get: (k: string) => number } }) =>
+        item.get('value') > 10;
+
+      const a = generateQueryId(
+        kSource,
+        predA,
+        kSortBy,
+        kCtx,
+        kNs,
+      );
+      const b = generateQueryId(
+        kSource,
+        predB,
+        kSortBy,
+        kCtx,
+        kNs,
+      );
+      assertTrue(a !== b, `IDs should differ: ${a}`);
+    },
+  );
+
+  TEST(
+    'QueryId',
+    'different ctx values produce different IDs',
+    () => {
+      const a = generateQueryId(
+        kSource,
+        kPredicate,
+        kSortBy,
+        { min: 5 },
+        kNs,
+      );
+      const b = generateQueryId(
+        kSource,
+        kPredicate,
+        kSortBy,
+        { min: 10 },
+        kNs,
+      );
+      assertTrue(a !== b, `IDs should differ: ${a}`);
+    },
+  );
+}

--- a/tests/query-id.test.ts
+++ b/tests/query-id.test.ts
@@ -1,12 +1,12 @@
 /**
- * Unit tests for `generateQueryId` — the deterministic cache-key function
- * that powers query deduplication and persistence.
+ * Unit tests for deterministic query identifiers that power query
+ * deduplication and persistence.
  *
  * These are pure-function tests (no DB, no I/O) so they run in <1ms.
  */
 import { assertEquals, assertTrue } from './asserts.ts';
 import { TEST } from './mod.ts';
-import { generateQueryId } from '../repo/query.ts';
+import { generateQueryId, resolveQueryId } from '../repo/query.ts';
 
 // Stable inputs used as baseline for all tests.
 const kSource = '/data/items';
@@ -76,64 +76,38 @@ export default function setup(): void {
 
   TEST(
     'QueryId',
-    'sortDescending:undefined produces a distinct ID from false and true',
+    'sortDescending:undefined resolves to the default false ID',
     () => {
-      const undef = generateQueryId(
-        kSource,
-        kPredicate,
-        kSortBy,
-        kCtx,
-        kNs,
-        undefined,
-        10,
-        true,
-      );
-      const falsy = generateQueryId(
-        kSource,
-        kPredicate,
-        kSortBy,
-        kCtx,
-        kNs,
-        false,
-        10,
-        true,
-      );
-      const truthy = generateQueryId(
-        kSource,
-        kPredicate,
-        kSortBy,
-        kCtx,
-        kNs,
-        true,
-        10,
-        true,
-      );
-      assertTrue(undef !== falsy, 'undefined vs false');
-      assertTrue(undef !== truthy, 'undefined vs true');
-      assertTrue(falsy !== truthy, 'false vs true');
+      const undef = resolveQueryId({ source: kSource });
+      const falsy = resolveQueryId({
+        source: kSource,
+        sortDescending: false,
+      });
+      const truthy = resolveQueryId({
+        source: kSource,
+        sortDescending: true,
+      });
+      assertEquals(undef, falsy);
+      assertTrue(undef !== truthy, 'false vs true');
     },
   );
 
   // --- limit independence ---------------------------------------------------
   TEST(
     'QueryId',
-    'different limit values produce different IDs',
+    'limit:undefined resolves to the default zero ID',
     () => {
-      const ids = [undefined, 0, 1, 10, 100].map((limit) =>
-        generateQueryId(
-          kSource,
-          kPredicate,
-          kSortBy,
-          kCtx,
-          kNs,
-          false,
-          limit,
-          true,
-        )
+      const defaults = [undefined, 0].map((limit) =>
+        resolveQueryId({ source: kSource, limit })
       );
-      // All 5 must be unique
-      const unique = new Set(ids);
-      assertEquals(unique.size, ids.length, `collision among limits: ${ids}`);
+      const nonDefaults = [1, 10, 100].map((limit) =>
+        resolveQueryId({ source: kSource, limit })
+      );
+      assertEquals(defaults[0], defaults[1]);
+      assertEquals(
+        new Set([...defaults, ...nonDefaults]).size,
+        nonDefaults.length + 1,
+      );
     },
   );
 
@@ -168,41 +142,19 @@ export default function setup(): void {
 
   TEST(
     'QueryId',
-    'liveUpdates:undefined produces a distinct ID from false and true',
+    'liveUpdates:undefined resolves to the default true ID',
     () => {
-      const undef = generateQueryId(
-        kSource,
-        kPredicate,
-        kSortBy,
-        kCtx,
-        kNs,
-        false,
-        10,
-        undefined,
-      );
-      const falsy = generateQueryId(
-        kSource,
-        kPredicate,
-        kSortBy,
-        kCtx,
-        kNs,
-        false,
-        10,
-        false,
-      );
-      const truthy = generateQueryId(
-        kSource,
-        kPredicate,
-        kSortBy,
-        kCtx,
-        kNs,
-        false,
-        10,
-        true,
-      );
-      assertTrue(undef !== falsy, 'undefined vs false');
-      assertTrue(undef !== truthy, 'undefined vs true');
-      assertTrue(falsy !== truthy, 'false vs true');
+      const undef = resolveQueryId({ source: kSource });
+      const falsy = resolveQueryId({
+        source: kSource,
+        liveUpdates: false,
+      });
+      const truthy = resolveQueryId({
+        source: kSource,
+        liveUpdates: true,
+      });
+      assertEquals(undef, truthy);
+      assertTrue(undef !== falsy, 'true vs false');
     },
   );
 

--- a/tests/query-id.test.ts
+++ b/tests/query-id.test.ts
@@ -6,7 +6,12 @@
  */
 import { assertEquals, assertTrue } from './asserts.ts';
 import { TEST } from './mod.ts';
-import { generateQueryId, resolveQueryId } from '../repo/query.ts';
+import {
+  generatedQueryIdsSize,
+  generateQueryId,
+  resetGeneratedQueryIds,
+  resolveQueryId,
+} from '../repo/query.ts';
 
 // Stable inputs used as baseline for all tests.
 const kSource = '/data/items';
@@ -218,6 +223,29 @@ export default function setup(): void {
     },
   );
 
+  // --- Generated-ID cache --------------------------------------------------
+  TEST(
+    'QueryId',
+    'generated-ID cache keeps at most 10,000 entries',
+    () => {
+      resetGeneratedQueryIds();
+      try {
+        for (let i = 0; i <= 10_000; i++) {
+          generateQueryId(
+            `/data/query-id-${i}`,
+            kPredicate,
+            kSortBy,
+            kCtx,
+            kNs,
+          );
+        }
+        assertEquals(generatedQueryIdsSize(), 10_000);
+      } finally {
+        resetGeneratedQueryIds();
+      }
+    },
+  );
+
   // --- Source type variants -------------------------------------------------
   TEST(
     'QueryId',
@@ -238,6 +266,25 @@ export default function setup(): void {
         kNs,
       );
       assertTrue(a !== b, `IDs should differ: ${a}`);
+    },
+  );
+
+  TEST(
+    'QueryId',
+    'equivalent repository and item paths produce the same ID',
+    () => {
+      const sources = [
+        '/data/items',
+        'data/items/',
+        '/data/items/item',
+        '/data/items/item/embed',
+      ];
+      const generatedIds = sources.map((source) =>
+        generateQueryId(source, kPredicate, kSortBy, kCtx, kNs)
+      );
+      const resolvedIds = sources.map((source) => resolveQueryId({ source }));
+      assertEquals(new Set(generatedIds).size, 1);
+      assertEquals(new Set(resolvedIds).size, 1);
     },
   );
 

--- a/tests/query-id.test.ts
+++ b/tests/query-id.test.ts
@@ -289,6 +289,100 @@ export default function setup(): void {
     },
   );
 
+  // --- Sentinel serialization ----------------------------------------------
+  TEST(
+    'QueryId',
+    'undefined, null, and string sentinels produce distinct IDs',
+    () => {
+      const sort = () => 0;
+      const ids = [
+        generateQueryId(kSource, kPredicate, kSortBy, kCtx, undefined),
+        generateQueryId(kSource, kPredicate, kSortBy, kCtx, null),
+        generateQueryId(kSource, kPredicate, kSortBy, kCtx, 'undefined'),
+        generateQueryId(kSource, kPredicate, kSortBy, kCtx, 'null'),
+        generateQueryId(kSource, kPredicate, kSortBy, kCtx, ''),
+        generateQueryId(kSource, kPredicate, undefined, kCtx, kNs),
+        generateQueryId(kSource, kPredicate, 'undefined', kCtx, kNs),
+        generateQueryId(kSource, kPredicate, 'null', kCtx, kNs),
+        generateQueryId(kSource, kPredicate, '', kCtx, kNs),
+        generateQueryId(kSource, kPredicate, sort, kCtx, kNs),
+      ];
+      assertEquals(new Set(ids).size, ids.length);
+    },
+  );
+
+  // --- ns independence ------------------------------------------------------
+  TEST(
+    'QueryId',
+    'different ns values produce different IDs',
+    () => {
+      const a = generateQueryId(
+        kSource,
+        kPredicate,
+        kSortBy,
+        kCtx,
+        'ns-a',
+      );
+      const b = generateQueryId(
+        kSource,
+        kPredicate,
+        kSortBy,
+        kCtx,
+        'ns-b',
+      );
+      const c = generateQueryId(
+        kSource,
+        kPredicate,
+        kSortBy,
+        kCtx,
+        undefined,
+      );
+      const d = generateQueryId(
+        kSource,
+        kPredicate,
+        kSortBy,
+        kCtx,
+        null,
+      );
+      assertTrue(a !== b, 'ns-a vs ns-b');
+      assertTrue(a !== c, 'ns-a vs undefined');
+      assertTrue(a !== d, 'ns-a vs null');
+      assertTrue(c !== d, 'undefined vs null');
+    },
+  );
+
+  // --- sortBy independence --------------------------------------------------
+  TEST(
+    'QueryId',
+    'different sortBy values produce different IDs',
+    () => {
+      const a = generateQueryId(
+        kSource,
+        kPredicate,
+        'name' as string,
+        kCtx,
+        kNs,
+      );
+      const b = generateQueryId(
+        kSource,
+        kPredicate,
+        'date' as string,
+        kCtx,
+        kNs,
+      );
+      const c = generateQueryId(
+        kSource,
+        kPredicate,
+        undefined,
+        kCtx,
+        kNs,
+      );
+      assertTrue(a !== b, 'name vs date');
+      assertTrue(a !== c, 'name vs undefined');
+      assertTrue(b !== c, 'date vs undefined');
+    },
+  );
+
   // --- Predicate / sortBy independence (pre-existing, lock down) ------------
   TEST(
     'QueryId',

--- a/tests/test-registry.ts
+++ b/tests/test-registry.ts
@@ -54,6 +54,7 @@ import setupMergeSync from './merge-sync.test.ts';
 import setupSecurityBoundaries from './security-boundaries.test.ts';
 import setupLiveQuery from './live-query.test.ts';
 import setupWriteFailure from './write-failure.test.ts';
+import setupQueryId from './query-id.test.ts';
 
 /**
  * Registers all test suites with the default TestsRunner.
@@ -78,6 +79,7 @@ export async function registerAllTests(): Promise<void> {
   setupBloomFPR(); // Bloom filter false-positive rate verification
   setupShardFormat(); // Shard file format read/write primitives
   setupAncestorLeafDetection(); // Ancestor edges and leaf detection via AdjacencyList
+  setupQueryId(); // generateQueryId cache-key determinism and uniqueness
 
   // COMPONENT TESTS (0-50ms each) - Single components with minimal dependencies
   setupBinaryEncoding(); // Binary commit format encoding roundtrip


### PR DESCRIPTION
**Note**: This PR was generated by an AI agent. If you'd like to talk with other humans, drop by our Discord!

---

## Summary

Fixes query ID collisions (issue #46) and ensures deterministic commit ordering within same-millisecond windows.

## Changes

### Query ID now includes all behavioural dimensions (`repo/query.ts`)
- **+** `sortDescending`, `limit`, `liveUpdates` in `generateQueryId` cache key
- **+** `queryIdPart` safe serialization (distinguishes `undefined`, `null`, functions, objects)
- **+** `resolveQueryId` — centralized ID resolution for all callers
- **~** `GoatDB.query` and `Query` constructor use `resolveQueryId` instead of inline computation

### Empty string query ID support (`repo/query-persistance.ts`)
- **~** `queryId ? map?.get(queryId)` → `queryId === undefined ? undefined : map?.get(queryId)`

### Monotonic clock for commit ordering (`repo/commit.ts`)
- **+** `nextMonotonicTimestamp()` — strictly increasing float64 within a single runtime
- **+** `nextFloat64()` — advance by 1 ULP when clock stalls
- **~** `Commit.create` uses `nextMonotonicTimestamp()` instead of `Date.now()`

### Tests
- **+** `tests/query-id.test.ts` — determinism, field combos, regression for issue #46
- **+** `tests/commit.test.ts` — stall, regression, epoch, precision, deserialization
- **+** `tests/merge-edge-cases.test.ts` — same-ms commit ordering
- **+** `tests/db-trusted.test.ts` — integration test for query ID namespace + sortBy

### Chore
- **~** `.gitignore` — add `.mcp.json`

## Breaking Changes
None. All public APIs remain the same. Query IDs are now **different** for queries that previously differed only in `sortDescending`, `limit`, or `liveUpdates` — any persisted query cache keyed by auto-generated ID will be recomputed.

---

Attached is an agent optimized description of the changes in this PR - [AGENT_REVIEW.md](https://github.com/user-attachments/files/30405281/AGENT_REVIEW.md)
