### PR TITLE
fix(collections): count elements instead of hash buckets in size

### DIFF
--- a/base/collections/hash-map.ts
+++ b/base/collections/hash-map.ts
@@ -65,6 +65,7 @@ export class HashSet<V> implements Iterable<V> {
   private readonly _hashFunc: HashFunction<V>;
   private readonly _equalFunc: EqualFunction<V>;
   private readonly _cloneFunc: CloneFunction<V>;
+  private _size = 0;
 
   /**
    * Initializes a new HashSet instance.
@@ -90,7 +91,7 @@ export class HashSet<V> implements Iterable<V> {
   }
 
   get size(): number {
-    return this._map.size;
+    return this._size;
   }
 
   add(v: V): boolean {
@@ -102,6 +103,7 @@ export class HashSet<V> implements Iterable<V> {
     if (values === undefined) {
       values = [this._cloneFunc(v)];
       map.set(key, values);
+      ++this._size;
       return true;
     }
 
@@ -115,6 +117,7 @@ export class HashSet<V> implements Iterable<V> {
 
     // If we got this far, v doesn't exist in the current list of values
     values.push(this._cloneFunc(v));
+    ++this._size;
     return true;
   }
 
@@ -138,6 +141,7 @@ export class HashSet<V> implements Iterable<V> {
         } else {
           values.splice(i, 1);
         }
+        --this._size;
         return true;
       }
     }
@@ -148,6 +152,7 @@ export class HashSet<V> implements Iterable<V> {
 
   clear(): void {
     this._map.clear();
+    this._size = 0;
   }
 
   get(v: V): V | undefined {

--- a/tests/hash-map.test.ts
+++ b/tests/hash-map.test.ts
@@ -1,0 +1,101 @@
+import { TEST } from './mod.ts';
+import { assertEquals, assertTrue } from './asserts.ts';
+import { dictEquals } from '../base/collections/dict.ts';
+import { HashMap, HashSet } from '../base/collections/hash-map.ts';
+
+function constantHash(): string {
+  return 'constant';
+}
+
+function stringsEqual(a: string, b: string): boolean {
+  return a === b;
+}
+
+function createHashMap(): HashMap<string, number> {
+  return new HashMap(constantHash, stringsEqual);
+}
+
+export default function setup() {
+  TEST('HashMap', 'counts colliding HashSet values through mutations', () => {
+    const set = new HashSet(constantHash, stringsEqual);
+
+    assertTrue(set.add('a'));
+    assertTrue(set.add('b'));
+    assertEquals(set.size, 2);
+    assertTrue(!set.add('a'));
+    assertEquals(set.size, 2);
+    assertTrue(set.delete('a'));
+    assertEquals(set.size, 1);
+    assertTrue(!set.has('a'));
+    assertTrue(set.has('b'));
+    assertTrue(!set.delete('missing'));
+    assertEquals(set.size, 1);
+    assertTrue(set.delete('b'));
+    assertEquals(set.size, 0);
+    assertTrue(set.add('b'));
+    assertEquals(set.size, 1);
+    set.clear();
+    assertEquals(set.size, 0);
+  });
+
+  TEST(
+    'HashMap',
+    'counts colliding entries through updates and removals',
+    () => {
+      const map = createHashMap();
+      map.set('a', 1);
+      map.set('b', 2);
+      assertEquals(map.size, 2);
+      map.set('b', 3);
+      assertEquals(map.size, 2);
+      assertEquals(map.get('b'), 3);
+      assertTrue(map.delete('a'));
+      assertEquals(map.size, 1);
+      assertTrue(!map.has('a'));
+      assertEquals(map.get('b'), 3);
+      assertTrue(map.delete('b'));
+      assertEquals(map.size, 0);
+      map.set('b', 4);
+      assertEquals(map.size, 1);
+      assertEquals(map.get('b'), 4);
+      map.clear();
+      assertEquals(map.size, 0);
+    },
+  );
+
+  TEST(
+    'HashMap',
+    'uses colliding entry cardinality for dictionary equality',
+    () => {
+      const one = createHashMap();
+      one.set('a', 1);
+      one.set('b', 2);
+
+      const two = createHashMap();
+      two.set('b', 2);
+      two.set('a', 1);
+
+      const different = createHashMap();
+      different.set('a', 1);
+      different.set('b', 3);
+
+      const fewer = createHashMap();
+      fewer.set('a', 1);
+
+      assertTrue(dictEquals(one, two));
+      assertTrue(!dictEquals(one, different));
+      assertTrue(!dictEquals(one, fewer));
+      assertTrue(!dictEquals(fewer, one));
+    },
+  );
+
+  TEST('HashMap', 'compares non-colliding maps correctly', () => {
+    const one = new HashMap((key: string) => key, stringsEqual);
+    one.set('a', 1);
+
+    const two = new HashMap((key: string) => key, stringsEqual);
+    two.set('a', 1);
+
+    assertTrue(dictEquals(one, two));
+  });
+}

--- a/tests/test-registry.ts
+++ b/tests/test-registry.ts
@@ -55,6 +55,7 @@ import setupSecurityBoundaries from './security-boundaries.test.ts';
 import setupLiveQuery from './live-query.test.ts';
 import setupWriteFailure from './write-failure.test.ts';
 import setupQueryId from './query-id.test.ts';
+import setupHashMap from './hash-map.test.ts';
 
 /**
  * Registers all test suites with the default TestsRunner.
@@ -80,6 +81,7 @@ export async function registerAllTests(): Promise<void> {
   setupShardFormat(); // Shard file format read/write primitives
   setupAncestorLeafDetection(); // Ancestor edges and leaf detection via AdjacencyList
   setupQueryId(); // generateQueryId cache-key determinism and uniqueness
+  setupHashMap(); // HashSet and HashMap collision-safe cardinality
 
   // COMPONENT TESTS (0-50ms each) - Single components with minimal dependencies
   setupBinaryEncoding(); // Binary commit format encoding roundtrip

--- a/tests/tests-entry-browser.ts
+++ b/tests/tests-entry-browser.ts
@@ -35,6 +35,7 @@ import setupGoatRequest from './goat-request.test.ts';
 import setupStaticAssetsEndpoint from './static-assets-endpoint.test.ts';
 import setupHealthCheckEndpoint from './health-check-endpoint.test.ts';
 import setupLiveQuery from './live-query.test.ts';
+import setupHashMap from './hash-map.test.ts';
 import { getEnvVar } from '../base/os.ts';
 import { notReached } from '../base/error.ts';
 
@@ -73,6 +74,7 @@ async function main(): Promise<void> {
   setupOrderstamp(); // Utility functions for distributed timestamps
   setupItemPath(); // Path validation and parsing logic
   setupHealthCheckEndpoint(); // Simple HTTP endpoint check
+  setupHashMap(); // HashSet and HashMap collision-safe cardinality
 
   // COMPONENT TESTS (0-50ms each) - Single components with minimal dependencies
   setupBinaryEncoding(); // Binary commit format encoding roundtrip


### PR DESCRIPTION
**Note**: This PR was generated by an AI agent. If you'd like to talk with other humans, drop by our Discord!

---

# HashSet/HashMap `size` now counts elements, not hash buckets

## What changed

`HashSet.size` (and `HashMap.size`) reported the number of hash **buckets** (`_map.size`) instead of stored **entries**. Under hash collisions, multiple entries share one bucket, so `size` undercounted — two entries with the same hash reported `1`.

**Changed** — `base/collections/hash-map.ts`
- `size` getter: `return this._map.size` → `return this._size`
- **Added** `_size` counter: `++` on both `add` paths, `--` on matched `delete`, `0` on `clear`

**Added** — `tests/hash-map.test.ts` (4 tests, worst case forced via constant hash → single bucket)
- Cardinality across add / duplicate add / update / delete / miss-delete / clear / re-add
- `dictEquals` cardinality gate: equal, value-mismatch, and entry-count-mismatch maps
- Non-colliding (identity hash) equality sanity check

**Changed** — test registration in both runtimes
- `tests/test-registry.ts` and `tests/tests-entry-browser.ts`: wired `setupHashMap()` into the fast-unit tier

## Why

`dictEquals` (used by deep equality in `base/core-types/equals.ts`) fast-fails on `size`. With bucket-count sizes, dictionaries of different cardinality could compare **equal** whenever keys collided — a silent data-equality bug. Same exposure in `base/adj-list.ts` edge sets.

## Impact

- **No breaking changes** — public API untouched; `size` is simply correct now.
- Tradeoff: O(1) counter means any future mutation path must update `_size`; the tests pin every mutation to catch drift.

---

Attached is an agent optimized description of the changes in this PR - [AGENT_REVIEW.md](https://github.com/user-attachments/files/30813292/AGENT_REVIEW.md)
